### PR TITLE
allow to specify an ID for secrets

### DIFF
--- a/manifests/conn.pp
+++ b/manifests/conn.pp
@@ -12,7 +12,6 @@ define strongswan::conn(
   validate_hash($options)
 
   concat::fragment { "ipsec_conf_conn-${conn_name}":
-    ensure  => present,
     content => template('strongswan/ipsec_conf_conn.erb'),
     target  => $strongswan::params::ipsec_conf,
     order   => '03',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,6 @@ class strongswan(
   }
 
   concat::fragment { 'ipsec_conf_header':
-    ensure  => present,
     content => template('strongswan/ipsec_conf_header.erb'),
     target  => $strongswan::params::ipsec_conf,
     order   => '01',
@@ -54,7 +53,6 @@ class strongswan(
   }
 
   concat::fragment { 'ipsec_secrets_header':
-    ensure  => present,
     content => template('strongswan/ipsec_secrets_header.erb'),
     target  => $strongswan::params::ipsec_secrets,
     order   => '01',

--- a/manifests/secrets.pp
+++ b/manifests/secrets.pp
@@ -13,7 +13,6 @@ define strongswan::secrets(
   validate_hash($options)
 
   concat::fragment { "ipsec_secrets_secret-${secrets_name}":
-    ensure  => present,
     content => template('strongswan/ipsec_secrets_secret.erb'),
     target  => $strongswan::params::ipsec_secrets,
     order   => '02',

--- a/manifests/secrets.pp
+++ b/manifests/secrets.pp
@@ -2,6 +2,7 @@
 define strongswan::secrets(
   $secrets_name = $title,
   $options = {},
+  $id = {},
 ) {
   # The base class must be included first because it is used by parameter
   # defaults.

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -5,7 +5,6 @@ class strongswan::setup(
   validate_hash($options)
 
   concat::fragment { 'ipsec_conf_setup':
-    ensure  => present,
     content => template('strongswan/ipsec_conf_setup.erb'),
     target  => $strongswan::params::ipsec_conf,
     order   => '02',

--- a/templates/ipsec_secrets_secret.erb
+++ b/templates/ipsec_secrets_secret.erb
@@ -1,5 +1,9 @@
 # Secrets for <%= @secrets_name %>.
 <% Array(@options).each do |option, setting| -%>
+<% if @id -%>
+<%= @id %> : <%= option %> <%= setting %>
+<% else -%>
 : <%= option %> <%= setting %>
+<% end -%>
 <% end -%>
 


### PR DESCRIPTION
This patch makes it possible to add an ID prefix for the secret (see [this link](https://wiki.strongswan.org/projects/strongswan/wiki/IpsecSecrets) for further information). If no @id parameter is defined it'll fallback to the previous behaviour.

```
strongswan::secrets { 'psk-tunnel':
  id => '10.0.1.1'
  options => {
    'PSK'        => 't00maNys3cR3ts',
  }
}
```
